### PR TITLE
Refactoring for Democles engine

### DIFF
--- a/org.emoflon.ibex.gt.democles/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.gt.democles/META-INF/MANIFEST.MF
@@ -10,4 +10,6 @@ Export-Package: org.emoflon.ibex.gt.democles.runtime
 Require-Bundle: org.emoflon.ibex.common,
  org.emoflon.ibex.gt,
  org.gervarro.democles.common,
+ org.gervarro.democles.interpreter.incremental,
+ org.gervarro.democles.notification.emf,
  org.gervarro.democles.specification.emf

--- a/org.emoflon.ibex.gt.democles/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.gt.democles/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: eMoflon::IBeX Developers
 Bundle-ActivationPolicy: lazy
 Export-Package: org.emoflon.ibex.gt.democles.runtime
-Require-Bundle: org.emoflon.ibex.common,
+Require-Bundle: org.eclipse.emf.ecore.xmi,
+ org.emoflon.ibex.common,
  org.emoflon.ibex.gt,
  org.gervarro.democles.common,
  org.gervarro.democles.interpreter.incremental,

--- a/org.emoflon.ibex.gt.democles/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.gt.democles/META-INF/MANIFEST.MF
@@ -11,6 +11,12 @@ Require-Bundle: org.eclipse.emf.ecore.xmi,
  org.emoflon.ibex.common,
  org.emoflon.ibex.gt,
  org.gervarro.democles.common,
+ org.gervarro.democles.emf,
+ org.gervarro.democles.interpreter,
+ org.gervarro.democles.interpreter.emf,
  org.gervarro.democles.interpreter.incremental,
+ org.gervarro.democles.interpreter.incremental.emf,
  org.gervarro.democles.notification.emf,
- org.gervarro.democles.specification.emf
+ org.gervarro.democles.plan.incremental.leaf,
+ org.gervarro.democles.specification.emf,
+ org.gervarro.notification

--- a/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
+++ b/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
@@ -121,6 +121,18 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 		this.savePatternsForDebugging();
 	}
 
+	/**
+	 * Saves the Democles patterns for debugging.
+	 */
+	private void savePatternsForDebugging() {
+		debugPath.ifPresent(path -> {
+			List<Pattern> sortedPatterns = patterns.stream() //
+					.sorted((p1, p2) -> p1.getName().compareTo(p2.getName())) // alphabetically by name
+					.collect(Collectors.toList());
+			ModelPersistenceUtils.saveModel(sortedPatterns, path + "/democles-patterns");
+		});
+	}
+
 	protected void createAndRegisterPatterns() {
 		// Democles configuration
 		EMFInterpretableIncrementalOperationBuilder<VariableRuntime> emfNativeOperationModule = configureDemocles();
@@ -210,19 +222,6 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 		ReteSearchPlanAlgorithm algorithm = new ReteSearchPlanAlgorithm();
 		builders.forEach(builder -> algorithm.addComponentBuilder(builder));
 		return algorithm;
-	}
-
-	/**
-	 * Saves the Democles patterns for debugging.
-	 */
-	private void savePatternsForDebugging() {
-		debugPath.ifPresent(path -> {
-			List<Pattern> sortedPatterns = patterns.stream().sorted((p1, p2) -> p1.getName().compareTo(p2.getName())) // alphabetically
-																														// by
-																														// name
-					.collect(Collectors.toList());
-			ModelPersistenceUtils.saveModel(sortedPatterns, path + "/democles-patterns");
-		});
 	}
 
 	@Override

--- a/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
+++ b/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
@@ -1,6 +1,7 @@
 package org.emoflon.ibex.gt.democles.runtime;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -12,6 +13,9 @@ import org.emoflon.ibex.common.operational.IPatternInterpreter;
 import org.emoflon.ibex.common.utils.ModelPersistenceUtils;
 import org.gervarro.democles.event.MatchEvent;
 import org.gervarro.democles.event.MatchEventListener;
+import org.gervarro.democles.incremental.emf.NotificationProcessor;
+import org.gervarro.democles.interpreter.incremental.rete.RetePattern;
+import org.gervarro.democles.interpreter.incremental.rete.RetePatternMatcherModule;
 import org.gervarro.democles.specification.emf.Pattern;
 
 import IBeXLanguage.IBeXPatternSet;
@@ -21,14 +25,47 @@ import IBeXLanguage.IBeXPatternSet;
  */
 public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener {
 	/**
+	 * The registry.
+	 */
+	protected Registry registry;
+
+	/**
+	 * The match observer.
+	 */
+	protected IMatchObserver app;
+
+	/**
+	 * The Democles patterns.
+	 */
+	protected Collection<Pattern> patterns = new ArrayList<Pattern>();
+
+	/**
+	 * The pattern matchers.
+	 */
+	protected Collection<RetePattern> patternMatchers;
+
+	/**
+	 * The pattern matcher module.
+	 */
+	protected RetePatternMatcherModule retePatternMatcherModule;
+
+	/**
+	 * The observer (??).
+	 */
+	protected NotificationProcessor observer;
+
+	/**
 	 * The path for debugging output.
 	 */
 	protected Optional<String> debugPath = Optional.empty();
 
 	/**
-	 * The Democles patterns.
+	 * Creates a new DemoclesGTEngine.
 	 */
-	private List<Pattern> patterns = new ArrayList<Pattern>();
+	public DemoclesGTEngine() {
+		this.patterns = new ArrayList<>();
+		this.patternMatchers = new ArrayList<>();
+	}
 
 	@Override
 	public void initPatterns(final IBeXPatternSet ibexPatternSet) {
@@ -51,8 +88,8 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 
 	@Override
 	public void initialise(Registry registry, IMatchObserver matchObserver) {
-		// TODO Auto-generated method stub
-
+		this.registry = registry;
+		this.app = matchObserver;
 	}
 
 	@Override
@@ -62,21 +99,19 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 	}
 
 	@Override
-	public void monitor(ResourceSet resourceSet) {
-		// TODO Auto-generated method stub
-
+	public void monitor(final ResourceSet resourceSet) {
+		this.observer.install(resourceSet);
 	}
 
 	@Override
 	public void updateMatches() {
-		// TODO Auto-generated method stub
-
+		// Trigger the Rete network.
+		this.retePatternMatcherModule.performIncrementalUpdates();
 	}
 
 	@Override
 	public void terminate() {
-		// TODO Auto-generated method stub
-
+		this.patternMatchers.forEach(pm -> pm.removeEventListener(this));
 	}
 
 	@Override

--- a/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
+++ b/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
@@ -3,6 +3,7 @@ package org.emoflon.ibex.gt.democles.runtime;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -16,13 +17,48 @@ import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.emoflon.ibex.common.operational.IMatchObserver;
 import org.emoflon.ibex.common.operational.IPatternInterpreter;
 import org.emoflon.ibex.common.utils.ModelPersistenceUtils;
+import org.gervarro.democles.common.PatternMatcherPlugin;
+import org.gervarro.democles.common.runtime.CategoryBasedQueueFactory;
+import org.gervarro.democles.common.runtime.ListOperationBuilder;
+import org.gervarro.democles.common.runtime.OperationBuilder;
+import org.gervarro.democles.common.runtime.Task;
+import org.gervarro.democles.common.runtime.VariableRuntime;
+import org.gervarro.democles.constraint.CoreConstraintModule;
+import org.gervarro.democles.constraint.emf.EMFConstraintModule;
 import org.gervarro.democles.event.MatchEvent;
 import org.gervarro.democles.event.MatchEventListener;
+import org.gervarro.democles.incremental.emf.ModelDeltaCategorizer;
 import org.gervarro.democles.incremental.emf.NotificationProcessor;
 import org.gervarro.democles.interpreter.incremental.rete.RetePattern;
 import org.gervarro.democles.interpreter.incremental.rete.RetePatternMatcherModule;
+import org.gervarro.democles.notification.emf.BidirectionalReferenceFilter;
+import org.gervarro.democles.notification.emf.EdgeDeltaFeeder;
+import org.gervarro.democles.notification.emf.ReferenceToEdgeConverter;
+import org.gervarro.democles.notification.emf.UndirectedEdgeToDirectedEdgeConverter;
+import org.gervarro.democles.operation.RelationalOperationBuilder;
+import org.gervarro.democles.operation.emf.DefaultEMFBatchAdornmentStrategy;
+import org.gervarro.democles.operation.emf.DefaultEMFIncrementalAdornmentStrategy;
+import org.gervarro.democles.operation.emf.EMFBatchOperationBuilder;
+import org.gervarro.democles.operation.emf.EMFIdentifierProviderBuilder;
+import org.gervarro.democles.operation.emf.EMFInterpretableIncrementalOperationBuilder;
+import org.gervarro.democles.plan.incremental.builder.AdornedNativeOperationDrivenComponentBuilder;
+import org.gervarro.democles.plan.incremental.builder.FilterComponentBuilder;
+import org.gervarro.democles.plan.incremental.leaf.Component;
+import org.gervarro.democles.plan.incremental.leaf.ReteSearchPlanAlgorithm;
+import org.gervarro.democles.runtime.AdornedNativeOperationBuilder;
+import org.gervarro.democles.runtime.InterpretableAdornedOperation;
+import org.gervarro.democles.runtime.JavaIdentifierProvider;
 import org.gervarro.democles.specification.emf.EMFDemoclesPatternMetamodelPlugin;
+import org.gervarro.democles.specification.emf.EMFPatternBuilder;
 import org.gervarro.democles.specification.emf.Pattern;
+import org.gervarro.democles.specification.emf.constraint.EMFTypeModule;
+import org.gervarro.democles.specification.emf.constraint.PatternInvocationTypeModule;
+import org.gervarro.democles.specification.emf.constraint.RelationalTypeModule;
+import org.gervarro.democles.specification.impl.DefaultPattern;
+import org.gervarro.democles.specification.impl.DefaultPatternBody;
+import org.gervarro.democles.specification.impl.DefaultPatternFactory;
+import org.gervarro.democles.specification.impl.PatternInvocationConstraintModule;
+import org.gervarro.notification.model.ModelDelta;
 
 import IBeXLanguage.IBeXPatternSet;
 
@@ -44,6 +80,11 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 	 * The Democles patterns.
 	 */
 	protected Collection<Pattern> patterns = new ArrayList<Pattern>();
+
+	/**
+	 * Democles pattern builder.
+	 */
+	protected EMFPatternBuilder<DefaultPattern, DefaultPatternBody> patternBuilder;
 
 	/**
 	 * The pattern matchers.
@@ -76,17 +117,109 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 	@Override
 	public void initPatterns(final IBeXPatternSet ibexPatternSet) {
 		IBeXToDemoclesPatternTransformation transformation = new IBeXToDemoclesPatternTransformation();
-		this.patterns = transformation.transform(ibexPatternSet);
+		patterns = transformation.transform(ibexPatternSet);
 		this.savePatternsForDebugging();
+	}
+
+	protected void createAndRegisterPatterns() {
+		// Democles configuration
+		EMFInterpretableIncrementalOperationBuilder<VariableRuntime> emfNativeOperationModule = configureDemocles();
+
+		// Build the pattern matchers in 2 phases
+		// 1) EMF-based to EMF-independent transformation
+		Collection<DefaultPattern> internalPatterns = patternBuilder.build(patterns);
+
+		// 2) EMF-independent to pattern matcher runtime (i.e., Rete network)
+		// transformation
+		retePatternMatcherModule.build(internalPatterns.toArray(new DefaultPattern[internalPatterns.size()]));
+		retePatternMatcherModule.getSession().setAutoCommitMode(false);
+
+		// Attach match listener to pattern matchers
+		patterns.forEach(pattern -> {
+			if (app.isPatternRelevantForCompiler(pattern.getName())) {
+				this.patternMatchers.add(retePatternMatcherModule.getPatternMatcher(getPatternID(pattern)));
+			}
+		});
+		patternMatchers.forEach(pm -> pm.addEventListener(this));
+
+		// Install model event listeners on the resource set
+		EdgeDeltaFeeder edgeDeltaFeeder = new EdgeDeltaFeeder(emfNativeOperationModule);
+		UndirectedEdgeToDirectedEdgeConverter undirectedEdgeToDirectedEdgeConverter = new UndirectedEdgeToDirectedEdgeConverter(
+				edgeDeltaFeeder);
+		ReferenceToEdgeConverter referenceToEdgeConverter = new ReferenceToEdgeConverter(
+				undirectedEdgeToDirectedEdgeConverter);
+		BidirectionalReferenceFilter bidirectionalReferenceFilter = new BidirectionalReferenceFilter(
+				referenceToEdgeConverter);
+		this.observer = new NotificationProcessor(bidirectionalReferenceFilter,
+				new CategoryBasedQueueFactory<ModelDelta>(ModelDeltaCategorizer.INSTANCE));
+	}
+
+	private EMFInterpretableIncrementalOperationBuilder<VariableRuntime> configureDemocles() {
+		EMFConstraintModule emfTypeModule = new EMFConstraintModule(registry);
+		EMFTypeModule internalEMFTypeModule = new EMFTypeModule(emfTypeModule);
+		RelationalTypeModule internalRelationalTypeModule = new RelationalTypeModule(CoreConstraintModule.INSTANCE);
+
+		patternBuilder = new EMFPatternBuilder<DefaultPattern, DefaultPatternBody>(new DefaultPatternFactory());
+		PatternInvocationConstraintModule<DefaultPattern, DefaultPatternBody> patternInvocationTypeModule //
+				= new PatternInvocationConstraintModule<DefaultPattern, DefaultPatternBody>(patternBuilder);
+		PatternInvocationTypeModule<DefaultPattern, DefaultPatternBody> internalPatternInvocationTypeModule //
+				= new PatternInvocationTypeModule<DefaultPattern, DefaultPatternBody>(patternInvocationTypeModule);
+		patternBuilder.addConstraintTypeSwitch(internalPatternInvocationTypeModule.getConstraintTypeSwitch());
+		patternBuilder.addConstraintTypeSwitch(internalRelationalTypeModule.getConstraintTypeSwitch());
+		patternBuilder.addConstraintTypeSwitch(internalEMFTypeModule.getConstraintTypeSwitch());
+		patternBuilder.addVariableTypeSwitch(internalEMFTypeModule.getVariableTypeSwitch());
+
+		retePatternMatcherModule = new RetePatternMatcherModule();
+		retePatternMatcherModule.setTaskQueueFactory(
+				new CategoryBasedQueueFactory<Task>(org.gervarro.democles.runtime.IncrementalTaskCategorizer.INSTANCE));
+
+		// EMF NativeOperation
+		EMFInterpretableIncrementalOperationBuilder<VariableRuntime> emfNativeOperationModule //
+				= new EMFInterpretableIncrementalOperationBuilder<VariableRuntime>(retePatternMatcherModule,
+						emfTypeModule);
+		// EMF batch
+		EMFBatchOperationBuilder<VariableRuntime> emfBatchOperationModule //
+				= new EMFBatchOperationBuilder<VariableRuntime>(emfNativeOperationModule,
+						DefaultEMFBatchAdornmentStrategy.INSTANCE);
+		EMFIdentifierProviderBuilder<VariableRuntime> emfIdentifierProviderModule //
+				= new EMFIdentifierProviderBuilder<VariableRuntime>(JavaIdentifierProvider.INSTANCE);
+		// Relational
+		ListOperationBuilder<InterpretableAdornedOperation, VariableRuntime> relationalOperationModule //
+				= new ListOperationBuilder<InterpretableAdornedOperation, VariableRuntime>(
+						new RelationalOperationBuilder<VariableRuntime>());
+		// EMF incremental
+		AdornedNativeOperationBuilder<VariableRuntime> emfIncrementalOperationModule //
+				= new AdornedNativeOperationBuilder<VariableRuntime>(emfNativeOperationModule,
+						DefaultEMFIncrementalAdornmentStrategy.INSTANCE);
+
+		ReteSearchPlanAlgorithm algorithm = this.initReteSearchPlanAlgorithm(Arrays.asList(
+				// EMF component
+				new AdornedNativeOperationDrivenComponentBuilder<VariableRuntime>(emfIncrementalOperationModule),
+				// Relational component
+				new FilterComponentBuilder<VariableRuntime>(relationalOperationModule)));
+		retePatternMatcherModule.setSearchPlanAlgorithm(algorithm);
+		retePatternMatcherModule.addOperationBuilder(emfBatchOperationModule);
+		retePatternMatcherModule.addOperationBuilder(relationalOperationModule);
+		retePatternMatcherModule.addIdentifierProviderBuilder(emfIdentifierProviderModule);
+
+		return emfNativeOperationModule;
+	}
+
+	protected ReteSearchPlanAlgorithm initReteSearchPlanAlgorithm(
+			Collection<OperationBuilder<Component, Component, VariableRuntime>> builders) {
+		ReteSearchPlanAlgorithm algorithm = new ReteSearchPlanAlgorithm();
+		builders.forEach(builder -> algorithm.addComponentBuilder(builder));
+		return algorithm;
 	}
 
 	/**
 	 * Saves the Democles patterns for debugging.
 	 */
 	private void savePatternsForDebugging() {
-		this.debugPath.ifPresent(path -> {
-			List<Pattern> sortedPatterns = this.patterns.stream()
-					.sorted((p1, p2) -> p1.getName().compareTo(p2.getName())) // alphabetically by name
+		debugPath.ifPresent(path -> {
+			List<Pattern> sortedPatterns = patterns.stream().sorted((p1, p2) -> p1.getName().compareTo(p2.getName())) // alphabetically
+																														// by
+																														// name
 					.collect(Collectors.toList());
 			ModelPersistenceUtils.saveModel(sortedPatterns, path + "/democles-patterns");
 		});
@@ -117,18 +250,18 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 
 	@Override
 	public void monitor(final ResourceSet resourceSet) {
-		this.observer.install(resourceSet);
+		observer.install(resourceSet);
 	}
 
 	@Override
 	public void updateMatches() {
 		// Trigger the Rete network.
-		this.retePatternMatcherModule.performIncrementalUpdates();
+		retePatternMatcherModule.performIncrementalUpdates();
 	}
 
 	@Override
 	public void terminate() {
-		this.patternMatchers.forEach(pm -> pm.removeEventListener(this));
+		patternMatchers.forEach(pm -> pm.removeEventListener(this));
 	}
 
 	@Override
@@ -146,5 +279,16 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 	public void handleEvent(final MatchEvent event) {
 		// TODO Auto-generated method stub
 		System.out.println("GTDemoclesEngine.handleEvent: " + event.getEventType() + " - " + event.getSource());
+	}
+
+	/**
+	 * Returns the pattern identifier for the given pattern.
+	 * 
+	 * @param pattern
+	 *            the Democles pattern
+	 * @return the identifier of the Democles pattern
+	 */
+	protected static String getPatternID(final Pattern pattern) {
+		return PatternMatcherPlugin.getIdentifier(pattern.getName(), pattern.getSymbolicParameters().size());
 	}
 }

--- a/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
+++ b/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
@@ -2,10 +2,11 @@ package org.emoflon.ibex.gt.democles.runtime;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.emoflon.ibex.common.operational.IPatternInterpreter;
 import org.emoflon.ibex.common.utils.ModelPersistenceUtils;
-import org.emoflon.ibex.gt.engine.GTEngine;
 import org.gervarro.democles.event.MatchEvent;
 import org.gervarro.democles.event.MatchEventListener;
 import org.gervarro.democles.specification.emf.Pattern;
@@ -13,24 +14,34 @@ import org.gervarro.democles.specification.emf.Pattern;
 import IBeXLanguage.IBeXPatternSet;
 
 /**
- * Engine for unidirectional graph transformations with Democles.
- * 
- * @author Patrick Robrecht
- * @version 0.1
+ * Engine for graph transformations with Democles.
  */
-public class DemoclesGTEngine extends GTEngine implements MatchEventListener {
+public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener {
+	/**
+	 * The path for debugging output.
+	 */
+	protected Optional<String> debugPath = Optional.empty();
+
 	/**
 	 * The Democles patterns.
 	 */
 	private List<Pattern> patterns = new ArrayList<Pattern>();
 
 	@Override
-	protected void transformPatterns(final IBeXPatternSet ibexPatternSet) {
+	public void setDebugPath(final String debugPath) {
+		this.debugPath = Optional.of(debugPath);
+	}
+
+	@Override
+	public void initPatterns(final IBeXPatternSet ibexPatternSet) {
 		IBeXToDemoclesPatternTransformation transformation = new IBeXToDemoclesPatternTransformation();
 		this.patterns = transformation.transform(ibexPatternSet);
 		this.savePatternsForDebugging();
 	}
 
+	/**
+	 * Saves the Democles patterns for debugging.
+	 */
 	private void savePatternsForDebugging() {
 		this.debugPath.ifPresent(path -> {
 			List<Pattern> sortedPatterns = this.patterns.stream()
@@ -41,7 +52,7 @@ public class DemoclesGTEngine extends GTEngine implements MatchEventListener {
 	}
 
 	/**
-	 * Handles {@link MatchEvent} from Democles.
+	 * Handles the {@link MatchEvent} from Democles.
 	 * 
 	 * @param event
 	 *            the MatchEvent to handle

--- a/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
+++ b/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.eclipse.emf.ecore.EPackage.Registry;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.emoflon.ibex.common.operational.IMatchObserver;
 import org.emoflon.ibex.common.operational.IPatternInterpreter;
 import org.emoflon.ibex.common.utils.ModelPersistenceUtils;
 import org.gervarro.democles.event.MatchEvent;
@@ -14,7 +17,7 @@ import org.gervarro.democles.specification.emf.Pattern;
 import IBeXLanguage.IBeXPatternSet;
 
 /**
- * Engine for graph transformations with Democles.
+ * Engine for (unidirectional) graph transformations with Democles.
  */
 public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener {
 	/**
@@ -26,11 +29,6 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 	 * The Democles patterns.
 	 */
 	private List<Pattern> patterns = new ArrayList<Pattern>();
-
-	@Override
-	public void setDebugPath(final String debugPath) {
-		this.debugPath = Optional.of(debugPath);
-	}
 
 	@Override
 	public void initPatterns(final IBeXPatternSet ibexPatternSet) {
@@ -49,6 +47,41 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 					.collect(Collectors.toList());
 			ModelPersistenceUtils.saveModel(sortedPatterns, path + "/democles-patterns");
 		});
+	}
+
+	@Override
+	public void initialise(Registry registry, IMatchObserver matchObserver) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public ResourceSet createAndPrepareResourceSet(String workspacePath) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void monitor(ResourceSet resourceSet) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void updateMatches() {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void terminate() {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void setDebugPath(final String debugPath) {
+		this.debugPath = Optional.of(debugPath);
 	}
 
 	/**

--- a/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
+++ b/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTEngine.java
@@ -1,5 +1,7 @@
 package org.emoflon.ibex.gt.democles.runtime;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -7,7 +9,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.ecore.EPackage.Registry;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.emoflon.ibex.common.operational.IMatchObserver;
 import org.emoflon.ibex.common.operational.IPatternInterpreter;
 import org.emoflon.ibex.common.utils.ModelPersistenceUtils;
@@ -16,6 +21,7 @@ import org.gervarro.democles.event.MatchEventListener;
 import org.gervarro.democles.incremental.emf.NotificationProcessor;
 import org.gervarro.democles.interpreter.incremental.rete.RetePattern;
 import org.gervarro.democles.interpreter.incremental.rete.RetePatternMatcherModule;
+import org.gervarro.democles.specification.emf.EMFDemoclesPatternMetamodelPlugin;
 import org.gervarro.democles.specification.emf.Pattern;
 
 import IBeXLanguage.IBeXPatternSet;
@@ -93,9 +99,20 @@ public class DemoclesGTEngine implements IPatternInterpreter, MatchEventListener
 	}
 
 	@Override
-	public ResourceSet createAndPrepareResourceSet(String workspacePath) {
-		// TODO Auto-generated method stub
-		return null;
+	public ResourceSet createAndPrepareResourceSet(final String workspacePath) {
+		ResourceSet resourceSet = new ResourceSetImpl();
+		// In contrast to EMFDemoclesPatternMetamodelPlugin.createDefaultResourceSet, we
+		// do not delegate directly to the global registry!
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap()
+				.put(Resource.Factory.Registry.DEFAULT_EXTENSION, new XMIResourceFactoryImpl());
+
+		try {
+			EMFDemoclesPatternMetamodelPlugin.setWorkspaceRootDirectory(resourceSet,
+					new File(workspacePath).getCanonicalPath());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return resourceSet;
 	}
 
 	@Override

--- a/org.emoflon.ibex.tgg.runtime.democles/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.tgg.runtime.democles/META-INF/MANIFEST.MF
@@ -25,6 +25,7 @@ Require-Bundle: org.apache.log4j,
  org.gervarro.democles.plan.incremental.leaf,
  org.gervarro.democles.notification.emf,
  org.emoflon.ibex.common,
+ org.emoflon.ibex.gt.democles;visibility:=reexport,
  org.emoflon.ibex.tgg.core.language,
  org.emoflon.ibex.tgg.core.runtime
 Bundle-ActivationPolicy: lazy

--- a/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesTGGEngine.java
+++ b/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesTGGEngine.java
@@ -1,6 +1,5 @@
 package org.emoflon.ibex.tgg.runtime.engine;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,8 +12,6 @@ import java.util.stream.Collectors;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.emoflon.ibex.common.operational.IMatch;
 import org.emoflon.ibex.gt.democles.runtime.DemoclesGTEngine;
 import org.emoflon.ibex.tgg.compiler.BlackPatternCompiler;
@@ -57,7 +54,6 @@ import org.gervarro.democles.plan.incremental.leaf.ReteSearchPlanAlgorithm;
 import org.gervarro.democles.runtime.AdornedNativeOperationBuilder;
 import org.gervarro.democles.runtime.InterpretableAdornedOperation;
 import org.gervarro.democles.runtime.JavaIdentifierProvider;
-import org.gervarro.democles.specification.emf.EMFDemoclesPatternMetamodelPlugin;
 import org.gervarro.democles.specification.emf.EMFPatternBuilder;
 import org.gervarro.democles.specification.emf.Pattern;
 import org.gervarro.democles.specification.emf.TypeModule;
@@ -306,25 +302,5 @@ public class DemoclesTGGEngine extends DemoclesGTEngine implements IBlackInterpr
 				});
 			}
 		});
-	}
-
-	@Override
-	public ResourceSet createAndPrepareResourceSet(final String workspacePath) {
-		ResourceSet rs = createDefaultResourceSet();
-		try {
-			EMFDemoclesPatternMetamodelPlugin.setWorkspaceRootDirectory(rs, new File(workspacePath).getCanonicalPath());
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		return rs;
-	}
-
-	private ResourceSet createDefaultResourceSet() {
-		final ResourceSet resourceSet = new ResourceSetImpl();
-		// In contrast to EMFDemoclesPatternMetamodelPlugin.createDefaultResourceSet, we
-		// do not delegate directly to the global registry!
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap()
-				.put(Resource.Factory.Registry.DEFAULT_EXTENSION, new XMIResourceFactoryImpl());
-		return resourceSet;
 	}
 }

--- a/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesTGGEngine.java
+++ b/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesTGGEngine.java
@@ -17,6 +17,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.emoflon.ibex.common.operational.IMatchObserver;
+import org.emoflon.ibex.gt.democles.runtime.DemoclesGTEngine;
 import org.emoflon.ibex.tgg.compiler.BlackPatternCompiler;
 import org.emoflon.ibex.tgg.compiler.patterns.common.IBlackPattern;
 import org.emoflon.ibex.tgg.operational.IBlackInterpreter;
@@ -37,7 +38,6 @@ import org.gervarro.democles.common.runtime.VariableRuntime;
 import org.gervarro.democles.constraint.CoreConstraintModule;
 import org.gervarro.democles.constraint.emf.EMFConstraintModule;
 import org.gervarro.democles.event.MatchEvent;
-import org.gervarro.democles.event.MatchEventListener;
 import org.gervarro.democles.incremental.emf.ModelDeltaCategorizer;
 import org.gervarro.democles.incremental.emf.NotificationProcessor;
 import org.gervarro.democles.interpreter.incremental.rete.RetePattern;
@@ -62,20 +62,22 @@ import org.gervarro.democles.runtime.JavaIdentifierProvider;
 import org.gervarro.democles.specification.emf.EMFDemoclesPatternMetamodelPlugin;
 import org.gervarro.democles.specification.emf.EMFPatternBuilder;
 import org.gervarro.democles.specification.emf.Pattern;
-import org.gervarro.democles.specification.emf.SpecificationPackage;
 import org.gervarro.democles.specification.emf.TypeModule;
 import org.gervarro.democles.specification.emf.constraint.EMFTypeModule;
 import org.gervarro.democles.specification.emf.constraint.PatternInvocationTypeModule;
 import org.gervarro.democles.specification.emf.constraint.RelationalTypeModule;
-import org.gervarro.democles.specification.emf.constraint.emf.emf.EMFTypePackage;
-import org.gervarro.democles.specification.emf.constraint.relational.RelationalConstraintPackage;
 import org.gervarro.democles.specification.impl.DefaultPattern;
 import org.gervarro.democles.specification.impl.DefaultPatternBody;
 import org.gervarro.democles.specification.impl.DefaultPatternFactory;
 import org.gervarro.democles.specification.impl.PatternInvocationConstraintModule;
 import org.gervarro.notification.model.ModelDelta;
 
-public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
+import IBeXLanguage.IBeXPatternSet;
+
+/**
+ * Engine for (bidirectional) graph transformations with Democles.
+ */
+public class DemoclesTGGEngine extends DemoclesGTEngine implements IBlackInterpreter {
 	private Registry registry;
 	private Collection<Pattern> patterns;
 	private HashMap<IDataFrame, Collection<IMatch>> matches;
@@ -83,35 +85,37 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 	private EMFPatternBuilder<DefaultPattern, DefaultPatternBody> patternBuilder;
 	private Collection<RetePattern> patternMatchers;
 	protected IMatchObserver app;
-	
+
 	private IbexOptions options;
 	private NotificationProcessor observer;
 
 	@Override
-	public void initialise(Registry registry, IMatchObserver app, IbexOptions options) {
+	public void initialise(Registry registry, IMatchObserver app) {
 		this.registry = registry;
-		this.options = options;
 		patterns = new ArrayList<>();
 		matches = new HashMap<>();
 		patternMatchers = new ArrayList<>();
 		this.app = app;
-		
+	}
+
+	public void setOptions(IbexOptions options) {
+		this.options = options;
 		createAndRegisterPatterns();
 	}
-	
+
 	@Override
 	public void monitor(ResourceSet rs) {
-		if (options.debug()){
-			saveDemoclesPatterns(rs);		
-			printReteNetwork(rs);
+		if (options.debug()) {
+			saveDemoclesPatterns(rs);
+			printReteNetwork();
 		}
-		
+
 		observer.install(rs);
 	}
 
 	private void createAndRegisterPatterns() {
 		// Create EMF-based pattern specification
-		createDemoclesPatterns();
+		initPatterns(null);
 
 		// Democles configuration
 		final EMFInterpretableIncrementalOperationBuilder<VariableRuntime> emfNativeOperationModule = configureDemocles();
@@ -120,23 +124,28 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 		// 1) EMF-based to EMF-independent transformation
 		final Collection<DefaultPattern> internalPatterns = patternBuilder.build(patterns);
 
-		// 2) EMF-independent to pattern matcher runtime (i.e., Rete network) transformation
+		// 2) EMF-independent to pattern matcher runtime (i.e., Rete network)
+		// transformation
 		retePatternMatcherModule.build(internalPatterns.toArray(new DefaultPattern[internalPatterns.size()]));
 		retePatternMatcherModule.getSession().setAutoCommitMode(false);
-		
+
 		// Attach match listener to pattern matchers
 		retrievePatternMatchers();
 		patternMatchers.forEach(pm -> pm.addEventListener(this));
 
 		// Install model event listeners on the resource set
 		EdgeDeltaFeeder edgeDeltaFeeder = new EdgeDeltaFeeder(emfNativeOperationModule);
-		UndirectedEdgeToDirectedEdgeConverter undirectedEdgeToDirectedEdgeConverter = new UndirectedEdgeToDirectedEdgeConverter(edgeDeltaFeeder);
-		ReferenceToEdgeConverter referenceToEdgeConverter = new ReferenceToEdgeConverter(undirectedEdgeToDirectedEdgeConverter);
-		BidirectionalReferenceFilter bidirectionalReferenceFilter = new BidirectionalReferenceFilter(referenceToEdgeConverter); 
-		observer = new NotificationProcessor(bidirectionalReferenceFilter, new CategoryBasedQueueFactory<ModelDelta>(ModelDeltaCategorizer.INSTANCE));
+		UndirectedEdgeToDirectedEdgeConverter undirectedEdgeToDirectedEdgeConverter = new UndirectedEdgeToDirectedEdgeConverter(
+				edgeDeltaFeeder);
+		ReferenceToEdgeConverter referenceToEdgeConverter = new ReferenceToEdgeConverter(
+				undirectedEdgeToDirectedEdgeConverter);
+		BidirectionalReferenceFilter bidirectionalReferenceFilter = new BidirectionalReferenceFilter(
+				referenceToEdgeConverter);
+		observer = new NotificationProcessor(bidirectionalReferenceFilter,
+				new CategoryBasedQueueFactory<ModelDelta>(ModelDeltaCategorizer.INSTANCE));
 	}
 
-	private void printReteNetwork(ResourceSet rs) {
+	private void printReteNetwork() {
 		for (final RetePattern retePattern : retePatternMatcherModule.getPatterns()) {
 			final List<RetePatternBody> bodies = retePattern.getBodies();
 			for (int i = 0; i < bodies.size(); i++) {
@@ -147,12 +156,10 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 	}
 
 	private void saveDemoclesPatterns(ResourceSet rs) {
-		Resource r = rs.createResource(URI.createPlatformResourceURI(options.projectPath() + "/debug/patterns.xmi", true));	
-		r.getContents().addAll(
-				patterns.stream()
-				  .sorted((p1, p2) -> p1.getName().compareTo(p2.getName()))
-				  .collect(Collectors.toList())
-				);
+		Resource r = rs
+				.createResource(URI.createPlatformResourceURI(options.projectPath() + "/debug/patterns.xmi", true));
+		r.getContents().addAll(patterns.stream().sorted((p1, p2) -> p1.getName().compareTo(p2.getName()))
+				.collect(Collectors.toList()));
 		try {
 			r.save(null);
 			rs.getResources().remove(r);
@@ -161,14 +168,16 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 		}
 	}
 
-	private void createDemoclesPatterns() {
+	@Override
+	public void initPatterns(final IBeXPatternSet ibexPatternSet) {
 		BlackPatternCompiler compiler = new BlackPatternCompiler(options);
 		compiler.preparePatterns();
 
-		IBlackToDemoclesPatternTransformation transformation = new IBlackToDemoclesPatternTransformation(this.options);	
+		IBlackToDemoclesPatternTransformation transformation = new IBlackToDemoclesPatternTransformation(this.options);
 		for (String r : compiler.getRuleToPatternMap().keySet()) {
 			for (IBlackPattern pattern : compiler.getRuleToPatternMap().get(r)) {
-				if (IBlackToDemoclesPatternTransformation.patternIsNotEmpty(pattern) && app.isPatternRelevantForCompiler(pattern.getName())) {
+				if (IBlackToDemoclesPatternTransformation.patternIsNotEmpty(pattern)
+						&& app.isPatternRelevantForCompiler(pattern.getName())) {
 					transformation.ibexToDemocles(pattern);
 				}
 			}
@@ -191,47 +200,56 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 	private EMFInterpretableIncrementalOperationBuilder<VariableRuntime> configureDemocles() {
 		final EMFConstraintModule emfTypeModule = new EMFConstraintModule(registry);
 		final EMFTypeModule internalEMFTypeModule = new EMFTypeModule(emfTypeModule);
-		final RelationalTypeModule internalRelationalTypeModule = new RelationalTypeModule(CoreConstraintModule.INSTANCE);
-		
+		final RelationalTypeModule internalRelationalTypeModule = new RelationalTypeModule(
+				CoreConstraintModule.INSTANCE);
+
 		patternBuilder = new EMFPatternBuilder<DefaultPattern, DefaultPatternBody>(new DefaultPatternFactory());
-		final PatternInvocationConstraintModule<DefaultPattern, DefaultPatternBody> patternInvocationTypeModule = new PatternInvocationConstraintModule<DefaultPattern, DefaultPatternBody>(patternBuilder);
-		final PatternInvocationTypeModule<DefaultPattern, DefaultPatternBody> internalPatternInvocationTypeModule = new PatternInvocationTypeModule<DefaultPattern, DefaultPatternBody>(patternInvocationTypeModule);
+		final PatternInvocationConstraintModule<DefaultPattern, DefaultPatternBody> patternInvocationTypeModule = new PatternInvocationConstraintModule<DefaultPattern, DefaultPatternBody>(
+				patternBuilder);
+		final PatternInvocationTypeModule<DefaultPattern, DefaultPatternBody> internalPatternInvocationTypeModule = new PatternInvocationTypeModule<DefaultPattern, DefaultPatternBody>(
+				patternInvocationTypeModule);
 		patternBuilder.addConstraintTypeSwitch(internalPatternInvocationTypeModule.getConstraintTypeSwitch());
 		patternBuilder.addConstraintTypeSwitch(internalRelationalTypeModule.getConstraintTypeSwitch());
 		patternBuilder.addConstraintTypeSwitch(internalEMFTypeModule.getConstraintTypeSwitch());
 		patternBuilder.addVariableTypeSwitch(internalEMFTypeModule.getVariableTypeSwitch());
 
 		retePatternMatcherModule = new RetePatternMatcherModule();
-		
-		retePatternMatcherModule.setTaskQueueFactory(new CategoryBasedQueueFactory<Task>(org.gervarro.democles.runtime.IncrementalTaskCategorizer.INSTANCE));
-		
+
+		retePatternMatcherModule.setTaskQueueFactory(
+				new CategoryBasedQueueFactory<Task>(org.gervarro.democles.runtime.IncrementalTaskCategorizer.INSTANCE));
+
 		// EMF native
 		// NativeOperation
-		final EMFInterpretableIncrementalOperationBuilder<VariableRuntime> emfNativeOperationModule = new EMFInterpretableIncrementalOperationBuilder<VariableRuntime>(retePatternMatcherModule, emfTypeModule);
+		final EMFInterpretableIncrementalOperationBuilder<VariableRuntime> emfNativeOperationModule = new EMFInterpretableIncrementalOperationBuilder<VariableRuntime>(
+				retePatternMatcherModule, emfTypeModule);
 		// EMF batch
-		final EMFBatchOperationBuilder<VariableRuntime> emfBatchOperationModule = new EMFBatchOperationBuilder<VariableRuntime>(emfNativeOperationModule, DefaultEMFBatchAdornmentStrategy.INSTANCE);
-		final EMFIdentifierProviderBuilder<VariableRuntime> emfIdentifierProviderModule = new EMFIdentifierProviderBuilder<VariableRuntime>(JavaIdentifierProvider.INSTANCE);
+		final EMFBatchOperationBuilder<VariableRuntime> emfBatchOperationModule = new EMFBatchOperationBuilder<VariableRuntime>(
+				emfNativeOperationModule, DefaultEMFBatchAdornmentStrategy.INSTANCE);
+		final EMFIdentifierProviderBuilder<VariableRuntime> emfIdentifierProviderModule = new EMFIdentifierProviderBuilder<VariableRuntime>(
+				JavaIdentifierProvider.INSTANCE);
 		// Relational
 		final ListOperationBuilder<InterpretableAdornedOperation, VariableRuntime> relationalOperationModule = new ListOperationBuilder<InterpretableAdornedOperation, VariableRuntime>(
-						new RelationalOperationBuilder<VariableRuntime>());
-		
+				new RelationalOperationBuilder<VariableRuntime>());
+
 		final ReteSearchPlanAlgorithm algorithm = new ReteSearchPlanAlgorithm();
 		// EMF incremental
-		final AdornedNativeOperationBuilder<VariableRuntime> emfIncrementalOperationModule = new AdornedNativeOperationBuilder<VariableRuntime>(emfNativeOperationModule, DefaultEMFIncrementalAdornmentStrategy.INSTANCE);
+		final AdornedNativeOperationBuilder<VariableRuntime> emfIncrementalOperationModule = new AdornedNativeOperationBuilder<VariableRuntime>(
+				emfNativeOperationModule, DefaultEMFIncrementalAdornmentStrategy.INSTANCE);
 		// EMF component
-		algorithm.addComponentBuilder(new AdornedNativeOperationDrivenComponentBuilder<VariableRuntime>(emfIncrementalOperationModule));
+		algorithm.addComponentBuilder(
+				new AdornedNativeOperationDrivenComponentBuilder<VariableRuntime>(emfIncrementalOperationModule));
 		// Relational component
 		algorithm.addComponentBuilder(new FilterComponentBuilder<VariableRuntime>(relationalOperationModule));
-		
+
 		retePatternMatcherModule.setSearchPlanAlgorithm(algorithm);
 		retePatternMatcherModule.addOperationBuilder(emfBatchOperationModule);
 		retePatternMatcherModule.addOperationBuilder(relationalOperationModule);
-	
+
 		retePatternMatcherModule.addIdentifierProviderBuilder(emfIdentifierProviderModule);
-		
+
 		// TGG attribute constraints
 		handleTGGAttributeConstraints(algorithm);
-		
+
 		return emfNativeOperationModule;
 	}
 
@@ -239,24 +257,23 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 		if (!this.options.blackInterpSupportsAttrConstrs()) {
 			return;
 		}
-		
+
 		TGGAttributeConstraintAdornmentStrategy.INSTANCE.setIsModelGen(options.isModelGen());
-		
+
 		// Handle constraints for the EMF to Java transformation
 		TGGAttributeConstraintModule.INSTANCE.registerConstraintTypes(options.constraintProvider());
-		TypeModule<TGGAttributeConstraintModule> tggAttributeConstraintTypeModule =
-				new TGGAttributeConstraintTypeModule(TGGAttributeConstraintModule.INSTANCE);
-		patternBuilder.addConstraintTypeSwitch(tggAttributeConstraintTypeModule.getConstraintTypeSwitch());		
-		
+		TypeModule<TGGAttributeConstraintModule> tggAttributeConstraintTypeModule = new TGGAttributeConstraintTypeModule(
+				TGGAttributeConstraintModule.INSTANCE);
+		patternBuilder.addConstraintTypeSwitch(tggAttributeConstraintTypeModule.getConstraintTypeSwitch());
+
 		// Native operation
-		final TGGNativeOperationBuilder<VariableRuntime> tggNativeOperationModule =
-				new TGGNativeOperationBuilder<VariableRuntime>(options.constraintProvider());
+		final TGGNativeOperationBuilder<VariableRuntime> tggNativeOperationModule = new TGGNativeOperationBuilder<VariableRuntime>(
+				options.constraintProvider());
 		// Batch operations
-		final EMFBatchOperationBuilder<VariableRuntime> tggBatchOperationModule =
-				new EMFBatchOperationBuilder<VariableRuntime>(tggNativeOperationModule,
-						TGGAttributeConstraintAdornmentStrategy.INSTANCE);
+		final EMFBatchOperationBuilder<VariableRuntime> tggBatchOperationModule = new EMFBatchOperationBuilder<VariableRuntime>(
+				tggNativeOperationModule, TGGAttributeConstraintAdornmentStrategy.INSTANCE);
 		retePatternMatcherModule.addOperationBuilder(tggBatchOperationModule);
-		
+
 		// Incremental operation
 		algorithm.addComponentBuilder(new TGGConstraintComponentBuilder<VariableRuntime>(tggNativeOperationModule));
 	}
@@ -276,11 +293,13 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 		final String type = event.getEventType();
 		final DataFrame frame = event.getMatching();
 
-		Optional<Pattern> p = patterns.stream().filter(pattern -> getPatternID(pattern).equals(event.getSource().toString())).findAny();
+		Optional<Pattern> p = patterns.stream()
+				.filter(pattern -> getPatternID(pattern).equals(event.getSource().toString())).findAny();
 
 		p.ifPresent(pattern -> {
 			// React to create
-			if (type.contentEquals(MatchEvent.INSERT) && (!matches.keySet().contains(frame) || matches.get(frame).stream().allMatch(m -> !m.getPatternName().equals(pattern.getName())))) {
+			if (type.contentEquals(MatchEvent.INSERT) && (!matches.keySet().contains(frame)
+					|| matches.get(frame).stream().allMatch(m -> !m.getPatternName().equals(pattern.getName())))) {
 				IMatch match = new DemoclesMatch(frame, pattern);
 				if (matches.keySet().contains(frame)) {
 					matches.get(frame).add(match);
@@ -293,7 +312,8 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 			// React to delete
 			if (type.equals(MatchEvent.DELETE)) {
 				Collection<IMatch> matchList = matches.get(frame);
-				Optional<IMatch> match = matchList == null ? Optional.empty() : matchList.stream().filter(m -> m.getPatternName().equals(pattern.getName())).findAny();
+				Optional<IMatch> match = matchList == null ? Optional.empty()
+						: matchList.stream().filter(m -> m.getPatternName().equals(pattern.getName())).findAny();
 
 				match.ifPresent(m -> {
 					app.removeMatch(m);
@@ -308,14 +328,7 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 	}
 
 	@Override
-	public void registerInternalMetamodels() {
-		SpecificationPackage.init();
-		RelationalConstraintPackage.init();
-		EMFTypePackage.init();
-	}
-
-	@Override
-	public ResourceSet createAndPrepareResourceSet(String workspacePath) {
+	public ResourceSet createAndPrepareResourceSet(final String workspacePath) {
 		ResourceSet rs = createDefaultResourceSet();
 		try {
 			EMFDemoclesPatternMetamodelPlugin.setWorkspaceRootDirectory(rs, new File(workspacePath).getCanonicalPath());
@@ -327,9 +340,10 @@ public class DemoclesEngine implements MatchEventListener, IBlackInterpreter {
 
 	private ResourceSet createDefaultResourceSet() {
 		final ResourceSet resourceSet = new ResourceSetImpl();
-		// In contrast to EMFDemoclesPatternMetamodelPlugin.createDefaultResourceSet, we do not delegate directly to the global registry!
-		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put(
-				Resource.Factory.Registry.DEFAULT_EXTENSION, new XMIResourceFactoryImpl());
+		// In contrast to EMFDemoclesPatternMetamodelPlugin.createDefaultResourceSet, we
+		// do not delegate directly to the global registry!
+		resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap()
+				.put(Resource.Factory.Registry.DEFAULT_EXTENSION, new XMIResourceFactoryImpl());
 		return resourceSet;
 	}
 }


### PR DESCRIPTION
Refactoring:
- `DemoclesGTEngine implements IPatternInterpreter, MatchEventListener`
- `DemoclesTGGEngine` (formerly `DemoclesEngine`) `extends DemoclesGTEngine implements IBlackInterpreter` -> Only TGG specific code is implemented here, everything else is inherited

Updated tests: https://github.com/eMoflon/emoflon-ibex-tests/pull/45