### PR TITLE
GT and TGG: Engine refactoring

### DIFF
--- a/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTMatch.java
+++ b/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/DemoclesGTMatch.java
@@ -1,0 +1,68 @@
+package org.emoflon.ibex.gt.democles.runtime;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.emoflon.ibex.common.operational.IMatch;
+import org.gervarro.democles.common.IDataFrame;
+import org.gervarro.democles.specification.emf.Pattern;
+
+/**
+ * A graph transformation match from Democles.
+ */
+public class DemoclesGTMatch implements IMatch {
+	/**
+	 * The Democles frame.
+	 */
+	private IDataFrame frame;
+
+	/**
+	 * The Democles pattern.
+	 */
+	protected Pattern pattern;
+
+	/**
+	 * Creates a new DemoclesGTMatch with the given frame and pattern.
+	 * 
+	 * @param frame
+	 *            the Democles frame
+	 * @param pattern
+	 *            the Democles pattern
+	 */
+	public DemoclesGTMatch(final IDataFrame frame, final Pattern pattern) {
+		this.frame = frame;
+		this.pattern = pattern;
+	}
+
+	@Override
+	public Object get(final String name) {
+		int index = parameterNameToIndex(name);
+		return index == -1 ? null : frame.getValue(index);
+	}
+
+	/**
+	 * Maps parameter variable names to Democles variable identifiers.
+	 * 
+	 * @param varName
+	 *            the variable
+	 * @return the id if it exists, -1 otherwise
+	 */
+	private int parameterNameToIndex(final String varName) {
+		for (int i = 0; i < pattern.getSymbolicParameters().size(); i++) {
+			if (varName.equals(pattern.getSymbolicParameters().get(i).getName())) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	@Override
+	public Collection<String> getParameterNames() {
+		return pattern.getSymbolicParameters().stream().map(p -> p.getName()).collect(Collectors.toList());
+	}
+
+	@Override
+	public String getPatternName() {
+		return pattern.getName();
+	}
+}

--- a/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/IBeXToDemoclesPatternTransformation.java
+++ b/org.emoflon.ibex.gt.democles/src/org/emoflon/ibex/gt/democles/runtime/IBeXToDemoclesPatternTransformation.java
@@ -71,7 +71,7 @@ public class IBeXToDemoclesPatternTransformation extends AbstractModelTransforma
 		PatternBody body = democlesSpecificationFactory.createPatternBody();
 		pattern.getBodies().add(body);
 
-		// Signature nodes -> parameter in Democles pattern.
+		// Signature nodes -> parameter in the Democles pattern.
 		Map<IBeXNode, EMFVariable> nodeToVariable = new HashMap<>();
 		ibexPattern.getSignatureNodes().forEach(ibexSignatureNode -> {
 			if (!nodeToVariable.containsKey(ibexSignatureNode)) {
@@ -80,12 +80,12 @@ public class IBeXToDemoclesPatternTransformation extends AbstractModelTransforma
 			pattern.getSymbolicParameters().add(nodeToVariable.get(ibexSignatureNode));
 		});
 
-		// Local node -> local variables in the Democles PatternBody.
+		// Local node -> parameter in the Democles PatternBody.
 		ibexPattern.getLocalNodes().forEach(ibexLocalNode -> {
 			if (!nodeToVariable.containsKey(ibexLocalNode)) {
 				nodeToVariable.put(ibexLocalNode, transformSignatureNodeToVariable(ibexLocalNode));
 			}
-			body.getLocalVariables().add(nodeToVariable.get(ibexLocalNode));
+			pattern.getSymbolicParameters().add(nodeToVariable.get(ibexLocalNode));
 		});
 
 		ibexPattern.getInjectivityConstraints().forEach(injectivityConstraint -> {

--- a/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesMatch.java
+++ b/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesMatch.java
@@ -1,48 +1,25 @@
 package org.emoflon.ibex.tgg.runtime.engine;
 
-import java.util.Collection;
-import java.util.stream.Collectors;
-
+import org.emoflon.ibex.gt.democles.runtime.DemoclesGTMatch;
 import org.emoflon.ibex.tgg.operational.matches.IMatch;
 import org.emoflon.ibex.tgg.operational.matches.SimpleMatch;
 import org.gervarro.democles.common.IDataFrame;
 import org.gervarro.democles.specification.emf.Pattern;
 
-public class DemoclesMatch implements IMatch {
-	private IDataFrame frame;
-	private Pattern pattern;
-
-	public DemoclesMatch(IDataFrame frame, Pattern pattern) {
-		this.frame = frame;
-		this.pattern = pattern;
-	}
-	
-	public Collection<String> getParameterNames() {
-		return pattern.getSymbolicParameters()
-				.stream()
-				.map(p -> p.getName())
-				.collect(Collectors.toList());
-	}
-
-	public Object get(String name) {
-		int index = varNameToIndex(name);
-		return index == -1 ? null : frame.getValue(index);
-	}
-
-	public String getPatternName() {
-		return pattern.getName();
-	}
-	
-	private int varNameToIndex(String varName) {
-		for(int i = 0; i < pattern.getSymbolicParameters().size(); i++){
-			if(varName.equals(pattern.getSymbolicParameters().get(i).getName()))
-				return i;
-		}
-		return -1;
-	}
-	
-	public String toString() {
-		return getPatternName();
+/**
+ * A TGG match from Democles.
+ */
+public class DemoclesMatch extends DemoclesGTMatch implements IMatch {
+	/**
+	 * Creates a new DemoclesMatch with the given frame and pattern.
+	 * 
+	 * @param frame
+	 *            the Democles frame
+	 * @param pattern
+	 *            the Democles pattern
+	 */
+	public DemoclesMatch(final IDataFrame frame, final Pattern pattern) {
+		super(frame, pattern);
 	}
 
 	@Override

--- a/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesTGGEngine.java
+++ b/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesTGGEngine.java
@@ -138,6 +138,6 @@ public class DemoclesTGGEngine extends DemoclesGTEngine implements IBlackInterpr
 
 	@Override
 	protected IMatch createMatch(final DataFrame frame, final Pattern pattern) {
-		return new DemoclesMatch(frame, pattern);
+		return new DemoclesTGGMatch(frame, pattern);
 	}
 }

--- a/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesTGGMatch.java
+++ b/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/DemoclesTGGMatch.java
@@ -9,7 +9,7 @@ import org.gervarro.democles.specification.emf.Pattern;
 /**
  * A TGG match from Democles.
  */
-public class DemoclesMatch extends DemoclesGTMatch implements IMatch {
+public class DemoclesTGGMatch extends DemoclesGTMatch implements IMatch {
 	/**
 	 * Creates a new DemoclesMatch with the given frame and pattern.
 	 * 
@@ -18,7 +18,7 @@ public class DemoclesMatch extends DemoclesGTMatch implements IMatch {
 	 * @param pattern
 	 *            the Democles pattern
 	 */
-	public DemoclesMatch(final IDataFrame frame, final Pattern pattern) {
+	public DemoclesTGGMatch(final IDataFrame frame, final Pattern pattern) {
 		super(frame, pattern);
 	}
 


### PR DESCRIPTION
- Refactor `handleEvent(...)` in Democles engines such that they use the same implementation in the parent class.
- Change transformation from `IBeXPattern`s to Democles `Pattern`s such that all nodes are transformed to symbolic parameters - otherwise they are not included in the Democles frame.