### PR TITLE
Exchangeable ILPSolver, NACs for Axioms 

### DIFF
--- a/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/IBlackToDemoclesPatternTransformation.java
+++ b/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/IBlackToDemoclesPatternTransformation.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.eclipse.emf.common.util.EList;
 import org.emoflon.ibex.tgg.compiler.patterns.common.IBlackPattern;
 import org.emoflon.ibex.tgg.compiler.patterns.common.IbexBasePattern;
+import org.emoflon.ibex.tgg.compiler.patterns.common.NacPattern;
 import org.emoflon.ibex.tgg.compiler.patterns.common.PatternInvocation;
 import org.emoflon.ibex.tgg.operational.defaults.IbexOptions;
 import org.gervarro.democles.specification.emf.Constraint;
@@ -77,7 +78,7 @@ public class IBlackToDemoclesPatternTransformation {
 		for (PatternInvocation inv : ibexPattern.getNegativeInvocations()) {
 			if (patternIsNotEmpty(inv.getInvokedPattern())) {
 				PatternInvocationConstraint invCon = createInvocationConstraint(inv, false, nodeToVar);
-				if(!invCon.getParameters().isEmpty())
+//				if(!invCon.getParameters().isEmpty())
 					constraints.add(invCon);
 			}
 		}
@@ -89,7 +90,20 @@ public class IBlackToDemoclesPatternTransformation {
 	}
 	
 	protected static boolean patternIsNotEmpty(IBlackPattern pattern) {
-		return !(pattern.getSignatureNodes().isEmpty() && pattern.getNegativeInvocations().isEmpty() && pattern.getPositiveInvocations().isEmpty());
+//		return !pattern.getSignatureNodes().isEmpty();
+		boolean hasNegativeInvocations = false;
+		for(PatternInvocation p : pattern.getNegativeInvocations()) {
+			if(patternIsNotEmpty(p.getInvokedPattern())) {
+				hasNegativeInvocations = true;
+			}
+		}
+		boolean hasPositiveInvocations = false;
+		for(PatternInvocation p : pattern.getPositiveInvocations()) {
+			if(patternIsNotEmpty(p.getInvokedPattern())) {
+				hasPositiveInvocations = true;
+			}
+		}
+		return !(pattern.getSignatureNodes().isEmpty() && !hasNegativeInvocations && !hasPositiveInvocations && pattern.getLocalNodes().isEmpty());
 	}
 
 	private EList<Constraint> ibexToDemocles(IBlackPattern ibexPattern, PatternBody body, Map<String, EMFVariable> nodeToVar, EList<Variable> parameters) {		

--- a/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/IBlackToDemoclesPatternTransformation.java
+++ b/org.emoflon.ibex.tgg.runtime.democles/src/org/emoflon/ibex/tgg/runtime/engine/IBlackToDemoclesPatternTransformation.java
@@ -89,7 +89,7 @@ public class IBlackToDemoclesPatternTransformation {
 	}
 	
 	protected static boolean patternIsNotEmpty(IBlackPattern pattern) {
-		return !pattern.getSignatureNodes().isEmpty();
+		return !(pattern.getSignatureNodes().isEmpty() && pattern.getNegativeInvocations().isEmpty() && pattern.getPositiveInvocations().isEmpty());
 	}
 
 	private EList<Constraint> ibexToDemocles(IBlackPattern ibexPattern, PatternBody body, Map<String, EMFVariable> nodeToVar, EList<Variable> parameters) {		


### PR DESCRIPTION
- Adds a common interface to use different wrappers
- Implements wrapper to use Gurobi and SAT4J
- Add option to Ibex options to select wrapper, make SAT4J default as it comes with eclipse and no other installations are required
- Fix check method that checks if patterns are empty -> now also checks pattern invocations and local Nodes
- Add new black pattern for Axiom NACs -> If found, Axiom is no applicable