### PR TITLE
Update site: Change emoflon.org URLs to HTTPS

### DIFF
--- a/docs/org.emoflon.ibex.tgg.ide.democles.feature/feature.xml
+++ b/docs/org.emoflon.ibex.tgg.ide.democles.feature/feature.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.emoflon.ibex.tgg.ide.democles.feature"
-      label="eMoflon::Ibex (Democles)"
+      label="eMoflon::IBeX (Democles)"
       version="1.0.0.qualifier"
-      provider-name="eMoflon Developers">
+      provider-name="eMoflon::IBeX Developers">
 
-   <description url="http://www.emoflon.org/">
+   <description url="https://emoflon.org/">
       This plugin provides support for unidirectional and bidirectional model transformation via graph transformation based on Democles as an incremental graph pattern matching engine.
    </description>
 
@@ -25,12 +25,12 @@ See here for more details on EPL: http://www.eclipse.org/org/documents/epl-v10.p
    </license>
 
    <url>
-      <update label="eMoflon::Ibex Update Site" url="https://emoflon.github.io/emoflon-ibex-democles/org.emoflon.ibex.tgg.ide.democles.updatesite/"/>
+      <update label="eMoflon::IBeX" url="https://emoflon.org/emoflon-ibex-democles/org.emoflon.ibex.tgg.ide.democles.updatesite/"/>
       <discovery label="Democles" url="http://gervarro.org/democles/integration-0.5.0/"/>
       <discovery label="Democles Advanced" url="http://gervarro.org/democles/advanced/integration-0.5.0/"/>
       <discovery label="PlantUML" url="http://files.idi.ntnu.no/publish/plantuml/repository/"/>
       <discovery label="Xtext" url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
-      <discovery label="eMoflon Core" url="http://emoflon.org/emoflon-core-updatesite/snapshot/updatesite/"/>
+      <discovery label="eMoflon Core" url="https://emoflon.org/emoflon-core-updatesite/snapshot/updatesite/"/>
    </url>
 
    <requires>


### PR DESCRIPTION
After emoflon.org supports HTTPS (https://github.com/eMoflon/emoflon-core/issues/82) we can change use HTTPS for all links on the update site.